### PR TITLE
switched to a simple version number

### DIFF
--- a/charts/onetimesecret/Chart.yaml
+++ b/charts/onetimesecret/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: onetimesecret
-version: 0.1.0
+version: 0.12.0
 description: A Helm chart for One-Time Secret server
 type: application
 keywords:

--- a/charts/onetimesecret/Chart.yaml
+++ b/charts/onetimesecret/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: onetimesecret
-version: 0.11-rc.1+igg0.2
+version: 0.1.0
 description: A Helm chart for One-Time Secret server
 type: application
 keywords:


### PR DESCRIPTION
* there is a known bug in the community that using a symantic version that includes a + symbol will break helm releases using releaser.  as the helm chart doesn't need to inherently specify the version of the app it uses there's no need to use a + so I revered to a simple 0.1.0