### PR TITLE
Fixed setting custom service port not working

### DIFF
--- a/charts/onetimesecret/Chart.yaml
+++ b/charts/onetimesecret/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: onetimesecret
-version: 0.12.0
+version: 0.12.1
 description: A Helm chart for One-Time Secret server
 type: application
 keywords:

--- a/charts/onetimesecret/templates/service.yaml
+++ b/charts/onetimesecret/templates/service.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   ports:
   - name: {{ include "common.names.fullname" . }}
-    port: {{ default .Values.networkPort .Values.servicePort }}
+    port: {{ default .Values.networkPort .Values.service.port }}
     protocol: TCP
   selector:
     app: {{ include "common.names.fullname" . }}


### PR DESCRIPTION
There was a typo in the `service` manifest that when setting a "Service Port", it would not work.  This has been fixed.