### PR TITLE
OTS: Fixed bugs/typos. Clarified values inline & in README. Minor improvements

### DIFF
--- a/charts/onetimesecret/Chart.yaml
+++ b/charts/onetimesecret/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: onetimesecret
-version: 0.12.0
+version: 0.12.1
 description: A Helm chart for One-Time Secret server
 type: application
 keywords:

--- a/charts/onetimesecret/README.md
+++ b/charts/onetimesecret/README.md
@@ -5,7 +5,7 @@
 ## TL;DR
 
 ```bash
-$ helm repo add indiegogo https://indiegogo.github.io/helm-charts
+$ helm repo add indiegogo https://charts.indiegogo.com
 $ helm install my-release indiegogo/onetimesecret
 ```
 
@@ -65,8 +65,9 @@ The command removes all the Kubernetes components associated with the chart and 
 
 | Name                                     | Type    | Description                                                                         | Default                     |
 | ---------------------------------------- | ------- | ----------------------------------------------------------------------------------- | --------------------------- |
-| `configuration.host`                     | string  | OTS host (the domain you will access OTS at)                                        | `"localhost:3000"`          |
+| `configuration.host`                     | string  | OTS host (the domain you will access OTS at)                                        | `"localhost"`               |
 | `configuration.ssl`                      | boolean | Enable SSL (HTTPS) support                                                          | `false`                     |
+| `configuration.baseRedisUrl`             | string  | Base Redis URL (see values.yaml for more info)                                      | `""`                        |
 | `configuration.colonels`                 | string  | OTS account created with this email is automatically considered admin of the system | `""`                        |
 | `configuration.secret`                   | string  | Used to encrypt OTS secrets - don't forget this, save it somewhere safe             | `"CHANGEME"`                |
 | `configuration.emailer.sendgridEnabled`  | boolean | Use SendGrid to allow OTS the ability to send emails                                | `false`                     |
@@ -83,41 +84,41 @@ The command removes all the Kubernetes components associated with the chart and 
 | `configuration.emailer.smtpPass`         | string  | SMTP password                                                                       | `nil`                       |
 | `configuration.emailer.smtpAuth`         | string  | SMTP authentication type. Allowed values: `plain` or `login`                        | `nil`                       |
 | `configuration.incoming.enabled`         | boolean | Intended for use by IT support teams who need someone to send them sensitive info   | `false`                     |
-| `configuration.incoming.email`           | string  | Where to send the "secret" link to                                                  | `nil`                       |
+| `configuration.incoming.email`           | string  | Where the secret link is sent                                                       | `"CHANGEME@example.com"`    |
 | `configuration.incoming.passphrase`      | string  | Used to protect the "secret"                                                        | `"CHANGEME"`                |
-| `configuration.incoming.regex`           | string  | Used to ensure the ticket number is valid                                           | `"\A[a-zA-Z0-9]{6}\z"`      |
+| `configuration.incoming.regex`           | string  | Used to ensure the ticket number is valid                                           | `'\A[a-zA-Z0-9]{6}\z'`      |
 
 
 ### Deployment parameters
 
-| Name                                | Type    | Description                                                    | Default                         |
-| ----------------------------------- | ------- | -------------------------------------------------------------- | ------------------------------- |
-| `image.registry`                    | string  | The Docker image registry                                      | `"gcr.io"`                      |
-| `image.repository`                  | string  | The Docker image repository                                    | `"indiegogo-com/onetimesecret"` |
-| `image.tag`                         | string  | The Docker image tag                                           | `'latest'`                      |
-| `image.pullPolicy`                  | string  | The Docker image pull policy                                   | `"IfNotPresent"`                |
-| `containerPort`                     | int     | OTS container port (overrides `networkPort`)                   | `nil`                           |
-| `replicaCount`                      | int     | Number of OTS replicas to deploy                               | `1`                             |
-| `strategy.type`                     | string  | Deployment strategy type                                       | `"RollingUpdate"`               |
-| `resources.requests`                | object  | CPU/memory resource requests                                   | `{}`                            |
-| `resources.limits`                  | object  | CPU/memory resource limits                                     | `{}`                            |
-| `livenessProbe.enabled`             | boolean | Enable/Disable the default tcpSocket livenessProbe             | `true`                          |
-| `livenessProbe.port`                | int     | Default livenessProbe tcpSocket port (overrides `networkPort`) | `3000`                          |
-| `livenessProbe.initialDelaySeconds` | int     | Initial delay seconds for livenessProbe                        | `30`                            |
-| `livenessProbe.periodSeconds`       | int     | Period seconds for livenessProbe                               | `nil`                           |
-| `livenessProbe.timeoutSeconds`      | int     | Timeout seconds for livenessProbe                              | `nil`                           |
-| `livenessProbe.successThreshold`    | int     | Success threshold for livenessProbe                            | `nil`                           |
-| `livenessProbe.failureThreshold`    | int     | Failure threshold for livenessProbe                            | `nil`                           |
-| `customLivenessProbe`               | object  | Custom livenessProbe that overrides the default one            | `{}`                            |
-| `readinessProbeEnabled`             | boolean | Enable the custom readinessProbe                               | `false`                         |
-| `readinessProbe`                    | object  | Write your custom readiness probe here                         | `{}`                            |
+| Name                                | Type    | Description                                                    | Default                            |
+| ----------------------------------- | ------- | -------------------------------------------------------------- | ---------------------------------- |
+| `image.registry`                    | string  | The Docker image registry                                      | `"gcr.io"`                         |
+| `image.repository`                  | string  | The Docker image repository                                    | `"indiegogo-public/onetimesecret"` |
+| `image.tag`                         | string  | The Docker image tag                                           | `'latest'`                         |
+| `image.pullPolicy`                  | string  | The Docker image pull policy                                   | `"IfNotPresent"`                   |
+| `containerPort`                     | int     | OTS container port (overrides `networkPort`)                   | `nil`                              |
+| `replicaCount`                      | int     | Number of OTS replicas to deploy                               | `1`                                |
+| `strategy.type`                     | string  | Deployment strategy type                                       | `"RollingUpdate"`                  |
+| `resources.requests`                | object  | CPU/memory resource requests                                   | `{}`                               |
+| `resources.limits`                  | object  | CPU/memory resource limits                                     | `{}`                               |
+| `livenessProbe.enabled`             | boolean | Enable/Disable the default tcpSocket livenessProbe             | `true`                             |
+| `livenessProbe.port`                | int     | Default livenessProbe tcpSocket port (overrides `networkPort`) | `nil`                              |
+| `livenessProbe.initialDelaySeconds` | int     | Initial delay seconds for livenessProbe                        | `30`                               |
+| `livenessProbe.periodSeconds`       | int     | Period seconds for livenessProbe                               | `nil`                              |
+| `livenessProbe.timeoutSeconds`      | int     | Timeout seconds for livenessProbe                              | `nil`                              |
+| `livenessProbe.successThreshold`    | int     | Success threshold for livenessProbe                            | `nil`                              |
+| `livenessProbe.failureThreshold`    | int     | Failure threshold for livenessProbe                            | `nil`                              |
+| `customLivenessProbe`               | object  | Custom livenessProbe that overrides the default one            | `{}`                               |
+| `readinessProbeEnabled`             | boolean | Enable the custom readinessProbe                               | `false`                            |
+| `readinessProbe`                    | object  | Write your custom readiness probe here                         | `{}`                               |
 
 
 ### Service parameters
 
 | Name           | Type    | Description                                 | Default      |
 | ---------------| ------- | ------------------------------------------- | ------------ |
-| `service.port` | int     | OTS Service port (overrides `networkPort`)  | `3000`       |
+| `service.port` | int     | OTS Service port (overrides `networkPort`)  | `nil`        |
 | `service.type` | string  | OTS Service Type                            | `"NodePort"` |
 
 
@@ -125,9 +126,9 @@ The command removes all the Kubernetes components associated with the chart and 
 
 | Name                        | Type    | Description                                          | Default |
 | --------------------------- | ------- | ---------------------------------------------------- | ------- |
-| `ingress.enabled`           | boolean | Enable/Disable Ingress                               | `false` |
-| `ingress.tls.enabled`       | boolean | Enable/Disable Ingress TLS                           | `true`  |
-| `ingress.tls.hosts`         | string  | Ingress TLS host(s)                                  | `nil`   |
+| `ingress.enabled`           | boolean | Enable/Disable Ingress                               | `true`  |
+| `ingress.tls.enabled`       | boolean | Enable/Disable Ingress TLS                           | `false` |
+| `ingress.tls.hosts`         | string  | Ingress TLS host(s)                                  | `""`    |
 | `ingress.tls.secretName`    | string  | Ingress TLS Secret name                              | `nil`   |
 | `ingress.rules.host`        | string  | Ingress rules host                                   | `nil`   |
 | `ingress.rules.path`        | string  | Ingress rules path                                   | `nil`   |

--- a/charts/onetimesecret/templates/configmap.yaml
+++ b/charts/onetimesecret/templates/configmap.yaml
@@ -10,12 +10,12 @@ metadata:
 data:
   config: |
     :site:
-      :host: <%= ENV['ONETIMESECRET_HOST'] || 'localhost:3000' %>
-      :domain: <%= ENV['ONETIMESECRET_HOST'] || 'localhost' %>
-      :ssl: <%= ENV['ONETIMESECRET_SSL'] == 'true' %>
+      :host: {{ print .Values.configuration.host ":" .Values.networkPort | squote }}
+      :domain: {{ required "'configuration.host' is required!" .Values.configuration.host }}
+      :ssl: <%= {{ .Values.configuration.ssl | squote }} == 'true' %>
       :secret: <%= ENV['ONETIMESECRET_SECRET'] || 'CHANGEME' %>
     :redis:
-      :uri: <%= (ENV['ONETIMESECRET_REDIS_URL'] || 'redis://redis:6379/0') + '?timeout=10&thread_safe=false&logging=false' %>
+      :uri: <%= {{ default (print "redis://" .Values.redis.fullnameOverride ":6379/0") .Values.configuration.baseRedisUrl | squote }} + '?timeout=10&thread_safe=false&logging=false' %>
     {{- if .Values.configuration.colonels }}
     :colonels:
       {{- range $value := split "," .Values.configuration.colonels }}
@@ -44,8 +44,8 @@ data:
       :host: {{ .Values.configuration.emailer.smtpHost }}
       :port: {{ .Values.configuration.emailer.smtpPort }}
       :tls: {{ .Values.configuration.emailer.smtpTls }}
-      :user: {{ .Values.configuration.emailer.smtpUser }}
-      :pass: {{ .Values.configuration.emailer.smtpPass }}
+      :user: {{ default "myUser" .Values.configuration.emailer.smtpUser }}
+      :pass: {{ default "myPassword" .Values.configuration.emailer.smtpPass }}
       :auth: {{ default "plain" .Values.configuration.emailer.smtpAuth }}
     {{- end }}
     {{- if .Values.configuration.incoming.enabled }}

--- a/charts/onetimesecret/templates/deployment.yaml
+++ b/charts/onetimesecret/templates/deployment.yaml
@@ -31,16 +31,6 @@ spec:
         {{- end }}
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
         env:
-        {{- if .Values.configuration.host }}
-        - name: ONETIMESECRET_HOST
-          value: {{ .Values.configuration.host | quote }}
-        {{- end }}
-        - name: ONETIMESECRET_SSL
-          value: {{ ternary "true" "false" .Values.configuration.ssl | quote }}
-        {{- if .Values.configuration.redisUrl }}
-        - name: ONETIMESECRET_REDIS_URL
-          value: {{ .Values.configuration.redisUrl | quote }}
-        {{- end }}
         - name: ONETIMESECRET_SECRET
           valueFrom:
             secretKeyRef:

--- a/charts/onetimesecret/templates/service.yaml
+++ b/charts/onetimesecret/templates/service.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   ports:
   - name: {{ include "common.names.fullname" . }}
-    port: {{ default .Values.networkPort .Values.servicePort }}
+    port: {{ default .Values.networkPort .Values.service.port }}
     protocol: TCP
   selector:
     app: {{ include "common.names.fullname" . }}

--- a/charts/onetimesecret/values.yaml
+++ b/charts/onetimesecret/values.yaml
@@ -22,14 +22,19 @@ configuration:
   host: "localhost"
   ## @param {boolean} configuration.ssl - Enable/disable SSL support
   ##
-  ssl: true
-  ## @param {string} configuration.redisUrl - Base Redis URL to be used
+  ssl: false
+  ## @param {string} configuration.baseRedisUrl - Base Redis URL to be used
   ## ("?timeout=10&thread_safe=false&logging=false" will be appended)
+  ## This paramater is used to set a custom Redis URL (hostname, port, etc.).
+  ## By default, the base Redis URL is composed of the redis.fullnameOverride
+  ## value in this file and a default port of 6379.
+  ## Ex.:
+  # baseRedisUrl: "redis://myRedisInstance:6379/0"
   ##
-  redisUrl: redis://redis:6379/0
+  baseRedisUrl: ""
   ## @param {string} configuration.colonels - One-Time Secret admin accounts, separated by commas
   ## e.g.:
-  ## colonels: "admin@example.com,user@example.com"
+  # colonels: "admin@example.com,user@example.com"
   ##
   colonels: ""
   ## @param {string} configuration.secret - One-Time Secret encryption secret
@@ -89,7 +94,7 @@ configuration:
     enabled: false
     ## @param {string} configuration.incoming.email - Receiving email address
     ##
-    email:
+    email: "CHANGEME@example.com"
     ## @param {string} configuration.incoming.passphrase - Passphrase of the "secret" link being sent to the email
     ##
     passphrase: CHANGEME
@@ -122,6 +127,9 @@ image:
 
 ## @section Deployment parameters
 
+## @param {integer} containerPort - Override the default port (`networkPort`) used in the container
+##
+containerPort:
 ## @param {integer} replicaCount - Number of One-Time Secret deployment replicas
 ##
 replicaCount: 1
@@ -177,9 +185,6 @@ readinessProbe: {}
 ## @param {integer} networkPort - Set the port to be used across the OTS container, livenessProbe, service, and ingress
 ##
 networkPort: 3000
-## @param {integer} containerPort - Override the default port (`networkPort`) used in the container
-##
-containerPort:
 ## Service parameters
 ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
 ## @param {integer} service.port - Override the default port (`networkPort`) used in the service
@@ -203,12 +208,12 @@ ingress:
   tls:
     ## @param {boolean} ingress.tls.enabled - Enable/disable ingress TLS support
     ##
-    enabled: true
+    enabled: false
     ## @param {string} ingress.tls.hosts - TLS host(s), separated by commas
     ##
-    hosts:
+    hosts: ""
     ## @param {string} ingress.tls.secretName - Name of the Kubernetes secret to store the TLS certificate
-    ## Defaults to the value of `configuration.host` and '-tls' is appended to the end
+    ## Defaults to the value of `configuration.host` with '-tls' appended to the end
     ##
     secretName:
   ## Ingress rule
@@ -240,18 +245,18 @@ ingress:
   ## ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
   ## If you do want to specify custom rules, use the example below to create your custom
   ## rule, and remove the square brackts after 'customRules:'.
-  ## e.g.:
-  ## customRules:
-  ## - host: example.com
-  ##   http:
-  ##     paths:
-  ##     - path: /
-  ##       pathType: Exact
-  ##       backend:
-  ##         service:
-  ##           name: myServiceName
-  ##           port:
-  ##             number: 8080
+  ## Ex.:
+  # customRules:
+  # - host: example.com
+  #   http:
+  #     paths:
+  #     - path: /
+  #       pathType: Exact
+  #       backend:
+  #         service:
+  #           name: myServiceName
+  #           port:
+  #             number: 3000
   ##
   customRules: []
   ## @param {Object} ingress.customAnnotations - Custom annotations
@@ -268,4 +273,4 @@ redis:
   chartEnabled: true
   ## @param {string} redis.fullnameOverride - Override the Redis chart name
   ##
-  fullnameOverride: redis
+  fullnameOverride: "redis"


### PR DESCRIPTION
Fixes several issues/typos.
- Bumped the chart version.
- Fixed typos and incorrect default values in the README.
- Improved the ConfigMap manifest by adding some default values and removing some ENV vars.
- Removed unnecessary ENV vars in the Deployment manifest.
- Fixed a typo in the Service manifest that when setting a "Service Port" would fail.
- Clarified how some values operate inside `values.yaml` and added necessary clarification to the README as well.