### PR TITLE
cloudinary-staging: Adjust Nginx config, add `q_auto,f_auto`

### DIFF
--- a/charts/cloudinary-staging/Chart.yaml
+++ b/charts/cloudinary-staging/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cloudinary-staging
-version: 0.1.0
-description: A Helm chart for Cloudinary
+version: 0.1.1
+description: A Helm chart for Cloudinary, used by Staging
 type: application
 keywords:
   - cloudinary

--- a/charts/cloudinary-staging/templates/configmap.yaml
+++ b/charts/cloudinary-staging/templates/configmap.yaml
@@ -51,6 +51,17 @@ data:
           return 200;
         }
 
+        # Of interesting note for the next two locations, you can't mix mapped
+        # variables with default capture variables ($1, $2, etc.) which is why
+        # these captures are named.
+
+        location ~ image/upload {
+          # Prepend both q_auto & f_auto for Cloudinary hosted assets.
+          # This allows for either to be overridden by setting the option again later.
+          rewrite ^(?!q_auto,f_auto.*)(?<prefix>.*?image/upload)/(?<postfix>.*)$ "${prefix}/q_auto,f_auto,${postfix}" break;
+          try_files /nonexistent @proxy;
+        }
+
         location ^~ /indiegogo-dev {
           # Strip the indiegogo-dev/ prefix
           rewrite ^/indiegogo-dev/(.*)$ /$1 last;
@@ -58,8 +69,6 @@ data:
 
         location ~ f_auto {
           # Replace f_auto with appropriate setting based on Accept headers.
-          # Of interesting note, you can't mix mapped variables with default capture
-          # variables ($1, $2, etc.) which is why these captures are named.
           rewrite ^(?<prefix>.*)f_auto(?<postfix>.*)$ "${prefix}${f_auto_setting}${postfix}" break;
           try_files /nonexistent @proxy;
         }


### PR DESCRIPTION
Force URL rewrite for Cloudinary hosted assets, adding `q_auto` & `f_auto`. Prepending these allows either to be overridden by setting the option again later.

This has been tested & verified.